### PR TITLE
Removed leading slash to iRMC API url

### DIFF
--- a/library/irmc_raid.py
+++ b/library/irmc_raid.py
@@ -362,7 +362,7 @@ def apply_raid_configuration(module, body):
 
 def get_raid_data(module):
     # make sure RAIDAdapter profile is up-to-date
-    status, sysdata, msg = irmc_redfish_delete(module, "/rest/v1/Oem/eLCM/ProfileManagement/RAIDAdapter")
+    status, sysdata, msg = irmc_redfish_delete(module, "rest/v1/Oem/eLCM/ProfileManagement/RAIDAdapter")
     if status < 100:
         module.fail_json(msg=msg, status=status, exception=sysdata)
     elif status not in (200, 202, 204, 404):
@@ -389,7 +389,7 @@ def get_raid_data(module):
         elif status not in (200, 202, 204):
             module.fail_json(msg=msg, log=data, status=status)
 
-    status, sysdata, msg = irmc_redfish_get(module, "/rest/v1/Oem/eLCM/ProfileManagement/RAIDAdapter")
+    status, sysdata, msg = irmc_redfish_get(module, "rest/v1/Oem/eLCM/ProfileManagement/RAIDAdapter")
     if status < 100:
         module.fail_json(msg=msg, status=status, exception=sysdata)
     elif status == 404:


### PR DESCRIPTION
When we were testing the Ansible integration we encountered strange behavior, after some research we fount that there were two slashes in front of the url. At first it looks like the module is working, but no changes are being posted and no error is given.

Credits to one of my die-hard python co-workers :-)